### PR TITLE
Implement post-quantum messaging pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,131 +1,107 @@
-# 𝘊𝘙𝘠𝘗𝘛𝘐𝘘 𝘘𝘶𝘢𝘯𝘵𝘶𝘮-𝘚𝘢𝘧𝘦 𝘊𝘩𝘢𝘵
+# 𝘊𝘙𝘠𝘗𝘛𝘐𝘘 — Post-Quantum Secure Messenger
 
-![Version](https://img.shields.io/badge/Version-v0.1.0-000000?style=for-the-badge\&logo=github\&logoColor=white)
-[![Python](https://img.shields.io/badge/Python-000000?style=for-the-badge\&logo=python\&logoColor=white)](https://www.python.org)
-[![Flask](https://img.shields.io/badge/Flask-000000?style=for-the-badge\&logo=flask\&logoColor=white)](https://flask.palletsprojects.com/)
+[![Version](https://img.shields.io/badge/Version-v1.0.0-000000?style=for-the-badge&logo=github&logoColor=white)](#)
+[![Python](https://img.shields.io/badge/Python-000000?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org)
+[![Flask](https://img.shields.io/badge/Flask-000000?style=for-the-badge&logo=flask&logoColor=white)](https://flask.palletsprojects.com/)
+[![Next.js](https://img.shields.io/badge/Next.js-000000?style=for-the-badge&logo=next.js&logoColor=white)](https://nextjs.org)
 [![MIT License](https://img.shields.io/badge/License-MIT-000000?style=for-the-badge)](LICENSE)
-[![Made by Nessa Kodo](https://img.shields.io/badge/Made%20by-Nessa%20Kodo-000000?style=for-the-badge)](https://nessakodo.com)
+
+CRYPTIQ is a full-stack reference implementation that demonstrates **practical post-quantum encrypted messaging**. The stack combines a Next.js front end with a Flask-SocketIO back end powered by NIST-selected primitives — Kyber-768 for key encapsulation and Dilithium-3 for digital signatures — via the [Open Quantum Safe](https://openquantumsafe.org) `oqs` bindings.
 
 ---
 
+## ✨ What’s new in this release
 
-## 𝘜𝘱𝘥𝘢𝘵𝘦𝘴
-
-CRYPTIQ v1.0 is a modern, real-time encrypted chat demo:
-
-* Built with **Next.js (frontend)** + **Flask-SocketIO (backend)**
-* **Glassmorphic, cyber-zen UI** with Orbitron + Inter fonts
-* **Quantum-safe encryption (Kyber, Dilithium)** concepts (future: E2E)
-* **Persistent in-memory chat history** for all new users joining
-* **Username support** for multi-user real-time demo
-* **Render/Vercel-ready** for instant deployment
+- **Real Kyber-768 + Dilithium-3 integration** using `oqs` with per-recipient encapsulation and Dilithium signatures over canonical payloads.
+- **Password-protected key vault**: user private keys are wrapped with scrypt + AES-GCM and persisted in SQLite through lightweight helpers.
+- **Authenticated sessions** with token-based login/logout, in-memory decrypted key cache, and Socket.IO join authorization.
+- **Encrypted message pipeline**: each outgoing message is signed, encapsulated for every recipient, sealed with AES-256-GCM, and verified on delivery.
+- **Cryptography-aware UI**: the chat surface shows signature verification state, ciphertext metadata, and exposes a decrypt helper endpoint for experimentation.
 
 ---
 
-## 𝘍𝘦𝘢𝘵𝘶𝘳𝘦𝘴
+## 🔐 Architecture overview
 
-* Realtime, broadcasted group chat
-* Username modal on entry (anonymous handle)
-* Distinct styling for each sender
-* Persistent chat history (for current server session)
-* Quantum cryptography banner and UI badge
-* Fully responsive, glassy UI
-* All code open source
+| Layer | Technology | Responsibilities |
+|-------|------------|------------------|
+| Frontend | Next.js + TailwindCSS | Auth modal, Socket.IO client, renders PQ telemetry and chat experience. |
+| Transport | Socket.IO | Authenticated, per-session channels for message fan-out. |
+| Backend | Flask, Flask-SocketIO | REST APIs for auth, message orchestration, PQ crypto operations. |
+| Crypto | `oqs`, PyCryptodome | Kyber-768 KEM, Dilithium-3 signatures, AES-256-GCM symmetric layer, scrypt password KDF. |
+| Persistence | SQLite | Users, sessions, messages, and per-recipient ciphertext packages. |
 
----
-
-## 𝘒𝘯𝘰𝘸𝘯 𝘉𝘶𝘨: 𝘊𝘩𝘢𝘵 𝘏𝘪𝘴𝘵𝘰𝘳𝘺 𝘎𝘭𝘪𝘵𝘤𝘩
-
-When new users join, they receive all past messages as history. However:
-
-* **Only messages sent after a user connects will appear in real time.**
-* If a user refreshes, they get the full previous history, but won't see any messages sent while they were disconnected.
-* If you have two users ("noa" and "zen"), and "zen" joins first, "zen" will *not* see "noa's" past messages until they refresh. This is by design of in-memory chat (not persistent in DB).
+### Message lifecycle
+1. **Registration/Login** – users supply a username + password. The backend mints Kyber/Dilithium keypairs, encrypts private keys with scrypt+AES, and returns public/private material to the client.
+2. **Session establishment** – successful auth stores decrypted keys in a locked session cache and issues a bearer token. Socket joins are validated against this token.
+3. **Send flow** – plaintext is canonicalised, Dilithium-signed, and encrypted for every recipient via Kyber encapsulation → AES-GCM. Each bundle is stored alongside the message record.
+4. **Receive flow** – recipients obtain encrypted payloads over Socket.IO. The server also verifies Dilithium signatures and, for convenience, attaches the decrypted plaintext plus raw cryptographic artefacts.
+5. **History sync** – reconnecting users replay their encrypted deliveries from SQLite, preserving signature verification state and ciphertext metadata.
 
 ---
 
-## 𝘐𝘯𝘵𝘦𝘳𝘧𝘢𝘤𝘦 𝘗𝘳𝘦𝘷𝘪𝘦𝘸𝘴
+## 🚀 Quick start
 
-### **Single User (First Join)**
-
-![1st user](./assets/1st.png)
-
-### **Multiple Users (Incognito Join)**
-
-![2nd user](./assets/2nd.png)
-
-
-*(Each user sees chat history up to their join time. Refreshing fetches full history.)*
-
----
-
-## 𝘏𝘰𝘸 𝘐𝘵 𝘞𝘰𝘳𝘬𝘴
-
-* **One backend, many frontends**: All browser tabs connect to the same Flask-SocketIO server
-* **Messages are broadcast** to all currently connected users
-* **Joining emits a “join” event** so the server sends full chat history to the new user
-* **Chat history is in-memory** (lost on backend restart, upgrade to DB planned)
-
----
-
-## 𝘘𝘶𝘪𝘤𝘬 𝘚𝘵𝘢𝘳𝘵 (𝘓𝘰𝘤𝘢𝘭 𝘙𝘶𝘯)
-
-### **Backend**
-
-* Python 3.8+, Flask, Flask-SocketIO
+### Backend
 
 ```bash
-pip3 install flask flask-socketio flask-cors
-python3 app.py
+cd backend
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+python -m backend.app
 ```
 
-* Runs at `http://localhost:5002`
+The API listens on `http://localhost:5002` and stores state in `backend/instance/cryptiq.db`.
 
-### **Frontend**
+> ℹ️ Install `pip install oqs` to enable true Kyber/Dilithium primitives. Without it the server falls back to a deterministic shim for development purposes.
 
-* Node 18+, Next.js, TailwindCSS
+### Frontend
 
 ```bash
+cd frontend
 npm install
 npm run dev
 ```
 
-* Runs at `http://localhost:3000`
-* Set `NEXT_PUBLIC_BACKEND_URL` in `.env.local` if needed
+Next.js serves the UI on `http://localhost:3000`. Set `NEXT_PUBLIC_BACKEND_URL` in `.env.local` if your backend runs elsewhere.
 
 ---
 
-## 𝘋𝘦𝘱𝘭𝘰𝘺 𝘖𝘯𝘭𝘪𝘯𝘦
+## 📡 API highlights
 
-* Backend: [Render](https://render.com/) (Flask Web Service)
-* Frontend: [Vercel](https://vercel.com/) or [Render](https://render.com/)
-* Set `NEXT_PUBLIC_BACKEND_URL` to your deployed backend URL
+- `POST /api/auth/register` – create an account, receive PQ key pairs (base64) and session token.
+- `POST /api/auth/login` – unlock stored keys and obtain a fresh token.
+- `POST /api/auth/logout` – invalidate the active token.
+- `GET /api/messages` – fetch encrypted deliveries for the authenticated user, including decrypted plaintext and Dilithium verification status.
+- `POST /api/messages` – submit plaintext; server signs, encrypts, stores, and broadcasts per-recipient packages.
+- `POST /api/messages/decrypt` – utility endpoint that decapsulates and decrypts a ciphertext bundle using the caller’s session keys.
 
----
-
-## 𝘚𝘢𝘮𝘱𝘭𝘦 𝘜𝘴𝘦
-
-1. Open two tabs (or incognito) to `localhost:3000/chat`
-2. Enter two different usernames
-3. Chat in real time; all messages sent after joining are visible in both tabs
+All protected routes expect a `Bearer <token>` header issued during login/registration.
 
 ---
 
-## 𝘗𝘭𝘢𝘯𝘯𝘦𝘥 𝘌𝘯𝘩𝘢𝘯𝘤𝘦𝘮𝘦𝘯𝘵𝘴 (v0.2+)
+## 🛡️ Security notes
 
-* Database-backed message history (survives restart)
-* End-to-end Kyber/Dilithium encryption (true post-quantum security)
-* User avatars
-* Room/DM support
-* Message reactions and typing indicators
+- **Post-quantum primitives** – Kyber-768 KEM and Dilithium-3 signatures via the Open Quantum Safe project.
+- **Symmetric confidentiality** – AES-256-GCM keys are derived from Kyber shared secrets using SHA-256.
+- **Key protection** – user private keys are encrypted at rest with scrypt-derived AES keys keyed by the user’s password.
+- **Session hygiene** – decrypted key material lives only in an in-memory cache bound to bearer tokens; tokens can be revoked with the logout endpoint.
+- **Telemetry** – every UI message shows signature verification state and exposes raw ciphertext/nonce/tag values to aid demonstrations and audits.
+
+> **Limitations:** the server currently performs encryption on behalf of clients so messages remain visible to the service for demo purposes. Bringing the same PQ operations to the browser (e.g., via WebAssembly) is the next step for full end-to-end secrecy.
+
+---
+
+## 🧪 Development tips
+
+- Run `pytest` inside `backend` to execute the crypto regression tests.
+- Delete `backend/instance/cryptiq.db` to reset users and message history.
+- Socket.IO broadcasts target only authenticated sessions; open multiple browser tabs and log in with different accounts to observe per-user ciphertext fan-out.
 
 ---
 
-## 𝘊𝘳𝘦𝘥𝘪𝘵𝘴
+## 📜 License & credits
 
-Created and maintained by [Nessa Kodo](https://nessakodo.com)
-Licensed under the MIT License.
+Created by [Nessa Kodo](https://nessakodo.com). Licensed under the MIT License.
 
-### 𝘘𝘶𝘢𝘯𝘵𝘶𝘮-𝘴𝘢𝘧𝘦 𝘤𝘩𝘢𝘵. 𝘍𝘰𝘳 𝘦𝘷𝘦𝘳𝘺 𝘧𝘶𝘵𝘶𝘳𝘦.
-
----
+“Quantum-safe chat. For every future.”

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,3 @@
+"""Expose the Flask application factory for external consumers."""
+
+from .app import create_app  # noqa: F401

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,30 +1,41 @@
+"""Application factory configuring the Cryptiq backend services."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
 from flask import Flask
 from flask_cors import CORS
-from flask_socketio import SocketIO, emit
-from routes.message_routes import message_routes
-from routes.auth_routes import auth_routes
 
-app = Flask(__name__)
-CORS(app)
-app.register_blueprint(message_routes)
-app.register_blueprint(auth_routes)
+from .storage import init_db
+from .routes.auth_routes import auth_routes
+from .routes.message_routes import message_routes
+from .session_cache import SessionCache
+from .socket_registry import SocketRegistry
+from .websocket.socket_server import socketio
 
-socketio = SocketIO(cors_allowed_origins='*')
-socketio.init_app(app, cors_allowed_origins='*')
 
-# In-memory message history
-messages = []
+def create_app() -> Flask:
+    app = Flask(__name__)
+    CORS(app)
 
-@socketio.on('send_message')
-def handle_send(data):
-    messages.append(data)
-    emit('receive_message', data, broadcast=True)
+    Path(app.instance_path).mkdir(parents=True, exist_ok=True)
+    init_db()
 
-@socketio.on('join')
-def handle_join():
-    # Send all previous messages to the new user (only to sender)
-    for msg in messages:
-        emit('receive_message', msg)
+    app.register_blueprint(auth_routes)
+    app.register_blueprint(message_routes)
+
+    app.config.setdefault("SESSION_CACHE", SessionCache())
+    app.config.setdefault("SOCKET_REGISTRY", SocketRegistry())
+    app.config.setdefault("NOW_FN", datetime.utcnow)
+
+    socketio.init_app(app, cors_allowed_origins="*")
+    return app
+
+
+app = create_app()
+
 
 if __name__ == "__main__":
     socketio.run(app, host="0.0.0.0", port=5002)

--- a/backend/crypto/dilithium_utils.py
+++ b/backend/crypto/dilithium_utils.py
@@ -1,6 +1,84 @@
-# Placeholder for Dilithium signature functions
-def sign(privkey, message):
-    return "signature"
+"""Dilithium-3 signature helpers with optional Open Quantum Safe support."""
 
-def verify(pubkey, message, signature):
-    return True
+from __future__ import annotations
+
+import base64
+import hmac
+import warnings
+from contextlib import contextmanager
+from typing import Iterator, Tuple
+
+from Crypto.Hash import SHA512
+from Crypto.Random import get_random_bytes
+
+try:  # pragma: no cover
+    import oqs
+
+    HAVE_OQS = True
+except Exception:  # pragma: no cover - deterministic shim
+    oqs = None
+    HAVE_OQS = False
+    warnings.warn(
+        "liboqs bindings not available. Falling back to deterministic Dilithium shim "
+        "(not quantum-safe). Install the 'oqs' package for real Dilithium-3 support.",
+        RuntimeWarning,
+    )
+
+
+@contextmanager
+def _sig() -> Iterator["oqs.Signature"]:
+    signer = oqs.Signature("Dilithium3")
+    try:
+        yield signer
+    finally:
+        signer.free()
+
+
+def _oqs_generate() -> Tuple[str, str]:
+    with _sig() as signer:
+        public_key, secret_key = signer.generate_keypair()
+    return base64.b64encode(public_key).decode(), base64.b64encode(secret_key).decode()
+
+
+def _oqs_sign(private_key_b64: str, message: bytes) -> str:
+    private_key = base64.b64decode(private_key_b64)
+    with _sig() as signer:
+        signature = signer.sign(message, private_key)
+    return base64.b64encode(signature).decode()
+
+
+def _oqs_verify(public_key_b64: str, message: bytes, signature_b64: str) -> bool:
+    public_key = base64.b64decode(public_key_b64)
+    signature = base64.b64decode(signature_b64)
+    with _sig() as signer:
+        return signer.verify(message, signature, public_key)
+
+
+def _shim_generate() -> Tuple[str, str]:
+    secret = get_random_bytes(32)
+    return base64.b64encode(secret).decode(), base64.b64encode(secret).decode()
+
+
+def _shim_sign(private_key_b64: str, message: bytes) -> str:
+    secret = base64.b64decode(private_key_b64)
+    signature = hmac.new(secret, message, SHA512).digest()
+    return base64.b64encode(signature).decode()
+
+
+def _shim_verify(public_key_b64: str, message: bytes, signature_b64: str) -> bool:
+    key = base64.b64decode(public_key_b64)
+    expected = hmac.new(key, message, SHA512).digest()
+    signature = base64.b64decode(signature_b64)
+    return hmac.compare_digest(expected, signature)
+
+
+def generate_keypair() -> Tuple[str, str]:
+    return _oqs_generate() if HAVE_OQS else _shim_generate()
+
+
+def sign(private_key_b64: str, message: bytes) -> str:
+    return _oqs_sign(private_key_b64, message) if HAVE_OQS else _shim_sign(private_key_b64, message)
+
+
+def verify(public_key_b64: str, message: bytes, signature_b64: str) -> bool:
+    return _oqs_verify(public_key_b64, message, signature_b64) if HAVE_OQS else _shim_verify(public_key_b64, message, signature_b64)

--- a/backend/crypto/keywrap.py
+++ b/backend/crypto/keywrap.py
@@ -1,0 +1,73 @@
+"""Helpers for encrypting sensitive key material with user passwords."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Dict
+
+from Crypto.Cipher import AES
+from Crypto.Protocol.KDF import scrypt
+from Crypto.Random import get_random_bytes
+
+
+SCRYPT_N = 2**14
+SCRYPT_R = 8
+SCRYPT_P = 1
+KEY_BYTES = 32
+NONCE_BYTES = 12
+SALT_BYTES = 16
+
+
+@dataclass
+class EncryptedBlob:
+    """Encrypted payload metadata stored in the database."""
+
+    salt: str
+    nonce: str
+    tag: str
+    ciphertext: str
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__)
+
+    @staticmethod
+    def from_json(data: str) -> "EncryptedBlob":
+        payload: Dict[str, str] = json.loads(data)
+        return EncryptedBlob(**payload)
+
+
+def _derive_key(password: str, salt: bytes) -> bytes:
+    return scrypt(password.encode("utf-8"), salt, KEY_BYTES, N=SCRYPT_N, r=SCRYPT_R, p=SCRYPT_P)
+
+
+def encrypt_secret(password: str, secret_b64: str) -> str:
+    """Encrypt a base64 encoded secret with a password and return JSON metadata."""
+
+    salt = get_random_bytes(SALT_BYTES)
+    key = _derive_key(password, salt)
+    nonce = get_random_bytes(NONCE_BYTES)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    ciphertext, tag = cipher.encrypt_and_digest(base64.b64decode(secret_b64))
+    blob = EncryptedBlob(
+        salt=base64.b64encode(salt).decode(),
+        nonce=base64.b64encode(nonce).decode(),
+        tag=base64.b64encode(tag).decode(),
+        ciphertext=base64.b64encode(ciphertext).decode(),
+    )
+    return blob.to_json()
+
+
+def decrypt_secret(password: str, payload_json: str) -> str:
+    """Decrypt a password-protected secret and return it encoded as base64."""
+
+    blob = EncryptedBlob.from_json(payload_json)
+    salt = base64.b64decode(blob.salt)
+    nonce = base64.b64decode(blob.nonce)
+    tag = base64.b64decode(blob.tag)
+    ciphertext = base64.b64decode(blob.ciphertext)
+    key = _derive_key(password, salt)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    secret = cipher.decrypt_and_verify(ciphertext, tag)
+    return base64.b64encode(secret).decode()

--- a/backend/crypto/kyber_utils.py
+++ b/backend/crypto/kyber_utils.py
@@ -1,9 +1,91 @@
-# Placeholder for Kyber PQC functions
-def generate_keys():
-    return "pubkey", "privkey"
+"""Kyber-768 helper utilities with optional Open Quantum Safe support."""
 
-def encrypt(pubkey, message):
-    return f"encrypted({message})"
+from __future__ import annotations
 
-def decrypt(privkey, ciphertext):
-    return f"decrypted({ciphertext})"
+import base64
+import warnings
+from contextlib import contextmanager
+from typing import Iterator, Tuple
+
+from Crypto.Hash import SHA256
+from Crypto.Random import get_random_bytes
+
+try:  # pragma: no cover - exercised in environments with liboqs installed
+    import oqs
+
+    HAVE_OQS = True
+except Exception:  # pragma: no cover - fall back to deterministic shim
+    oqs = None
+    HAVE_OQS = False
+    warnings.warn(
+        "liboqs bindings not available. Falling back to deterministic Kyber shim "
+        "(not quantum-safe). Install the 'oqs' package for real Kyber-768 support.",
+        RuntimeWarning,
+    )
+
+
+@contextmanager
+def _kem() -> Iterator["oqs.KeyEncapsulation"]:
+    kem = oqs.KeyEncapsulation("Kyber768")
+    try:
+        yield kem
+    finally:
+        kem.free()
+
+
+def _oqs_generate() -> Tuple[str, str]:
+    with _kem() as kem:
+        public_key, secret_key = kem.generate_keypair()
+    return base64.b64encode(public_key).decode(), base64.b64encode(secret_key).decode()
+
+
+def _oqs_encapsulate(public_key_b64: str) -> Tuple[str, str]:
+    public_key = base64.b64decode(public_key_b64)
+    with _kem() as kem:
+        ciphertext, shared_secret = kem.encapsulate(public_key)
+    return base64.b64encode(ciphertext).decode(), base64.b64encode(shared_secret).decode()
+
+
+def _oqs_decapsulate(secret_key_b64: str, ciphertext_b64: str) -> str:
+    secret_key = base64.b64decode(secret_key_b64)
+    ciphertext = base64.b64decode(ciphertext_b64)
+    with _kem() as kem:
+        shared_secret = kem.decapsulate(ciphertext, secret_key)
+    return base64.b64encode(shared_secret).decode()
+
+
+def _shim_generate() -> Tuple[str, str]:
+    secret = get_random_bytes(32)
+    return base64.b64encode(secret).decode(), base64.b64encode(secret).decode()
+
+
+def _shim_encapsulate(public_key_b64: str) -> Tuple[str, str]:
+    public_key = base64.b64decode(public_key_b64)
+    nonce = get_random_bytes(32)
+    shared_secret = SHA256.new(public_key + nonce).digest()
+    return base64.b64encode(nonce).decode(), base64.b64encode(shared_secret).decode()
+
+
+def _shim_decapsulate(secret_key_b64: str, ciphertext_b64: str) -> str:
+    secret_key = base64.b64decode(secret_key_b64)
+    nonce = base64.b64decode(ciphertext_b64)
+    shared_secret = SHA256.new(secret_key + nonce).digest()
+    return base64.b64encode(shared_secret).decode()
+
+
+def generate_keypair() -> Tuple[str, str]:
+    """Generate a Kyber-768 keypair encoded as base64 strings."""
+
+    return _oqs_generate() if HAVE_OQS else _shim_generate()
+
+
+def encapsulate(public_key_b64: str) -> Tuple[str, str]:
+    """Encapsulate a shared secret to the provided base64 encoded public key."""
+
+    return _oqs_encapsulate(public_key_b64) if HAVE_OQS else _shim_encapsulate(public_key_b64)
+
+
+def decapsulate(secret_key_b64: str, ciphertext_b64: str) -> str:
+    """Recover the shared secret from the base64 encoded secret key and ciphertext."""
+
+    return _oqs_decapsulate(secret_key_b64, ciphertext_b64) if HAVE_OQS else _shim_decapsulate(secret_key_b64, ciphertext_b64)

--- a/backend/crypto/protocol.py
+++ b/backend/crypto/protocol.py
@@ -1,0 +1,27 @@
+"""Shared helpers for constructing signed payloads and timestamps."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def canonical_timestamp(timestamp: datetime) -> str:
+    """Return an ISO-8601 UTC timestamp string with a trailing Z."""
+
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    else:
+        timestamp = timestamp.astimezone(timezone.utc)
+    return timestamp.isoformat().replace("+00:00", "Z")
+
+
+def build_signature_payload(sender_username: str, plaintext: bytes, timestamp_iso: str) -> bytes:
+    """Create a canonical byte payload for Dilithium signatures."""
+
+    return b"|".join(
+        [
+            sender_username.encode("utf-8"),
+            timestamp_iso.encode("utf-8"),
+            plaintext,
+        ]
+    )

--- a/backend/crypto/symmetric.py
+++ b/backend/crypto/symmetric.py
@@ -1,0 +1,50 @@
+"""Symmetric encryption helpers layered on top of Kyber shared secrets."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from hashlib import sha256
+
+from Crypto.Cipher import AES
+from Crypto.Random import get_random_bytes
+
+
+NONCE_BYTES = 12
+
+
+@dataclass
+class CipherBundle:
+    nonce: str
+    ciphertext: str
+    tag: str
+
+
+def _derive_key(shared_secret_b64: str) -> bytes:
+    secret_bytes = base64.b64decode(shared_secret_b64)
+    return sha256(secret_bytes).digest()
+
+
+def encrypt(shared_secret_b64: str, plaintext: bytes) -> CipherBundle:
+    """Encrypt plaintext bytes using AES-256-GCM derived from the shared secret."""
+
+    key = _derive_key(shared_secret_b64)
+    nonce = get_random_bytes(NONCE_BYTES)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    ciphertext, tag = cipher.encrypt_and_digest(plaintext)
+    return CipherBundle(
+        nonce=base64.b64encode(nonce).decode(),
+        ciphertext=base64.b64encode(ciphertext).decode(),
+        tag=base64.b64encode(tag).decode(),
+    )
+
+
+def decrypt(shared_secret_b64: str, nonce_b64: str, tag_b64: str, ciphertext_b64: str) -> bytes:
+    """Decrypt ciphertext bytes using AES-256-GCM derived from the shared secret."""
+
+    key = _derive_key(shared_secret_b64)
+    nonce = base64.b64decode(nonce_b64)
+    tag = base64.b64decode(tag_b64)
+    ciphertext = base64.b64decode(ciphertext_b64)
+    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+    return cipher.decrypt_and_verify(ciphertext, tag)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
+eventlet
 flask
 flask-cors
 flask-socketio
-pycryptodome
-eventlet
 gunicorn
+pycryptodome
+pytest

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -1,8 +1,138 @@
-from flask import Blueprint, request, jsonify
+"""Authentication endpoints handling registration, login, and logout."""
 
-auth_routes = Blueprint('auth', __name__)
+from __future__ import annotations
 
-@auth_routes.route('/api/login', methods=['POST'])
-def login():
-    # Accepts username/password, returns dummy token
-    return jsonify({"token": "dummy-token"})
+import secrets
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from flask import Blueprint, current_app, jsonify, request
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from ..crypto import dilithium_utils, keywrap, kyber_utils, protocol
+from .. import storage
+
+
+auth_routes = Blueprint("auth", __name__)
+
+
+def _get_json() -> Dict[str, Any]:
+    return request.get_json(force=True, silent=True) or {}
+
+
+def _extract_token() -> Optional[str]:
+    header = request.headers.get("Authorization", "")
+    if header.startswith("Bearer "):
+        return header[7:]
+    data = _get_json()
+    token = data.get("token") if isinstance(data, dict) else None
+    return token
+
+
+SESSION_DURATION_HOURS = 12
+
+
+def _cache_session(token: str, user: Dict[str, Any], kyber_priv: str, dilithium_priv: str) -> None:
+    cache = current_app.config["SESSION_CACHE"]
+    cache.store(
+        token,
+        {
+            "user_id": user["id"],
+            "username": user["username"],
+            "kyber_private_key": kyber_priv,
+            "dilithium_private_key": dilithium_priv,
+            "kyber_public_key": user["kyber_public_key"],
+            "dilithium_public_key": user["dilithium_public_key"],
+        },
+    )
+
+
+def _session_payload(user: Dict[str, Any], token: str, kyber_priv: str, dilithium_priv: str) -> Dict[str, Any]:
+    created_at = user.get("created_at")
+    if isinstance(created_at, str):
+        created_at = datetime.fromisoformat(created_at)
+    return {
+        "token": token,
+        "user": {
+            "id": user["id"],
+            "username": user["username"],
+            "created_at": protocol.canonical_timestamp(created_at),
+        },
+        "keys": {
+            "kyber": {"public": user["kyber_public_key"], "private": kyber_priv},
+            "dilithium": {
+                "public": user["dilithium_public_key"],
+                "private": dilithium_priv,
+            },
+        },
+    }
+
+
+@auth_routes.route("/api/auth/register", methods=["POST"])
+def register() -> Any:
+    data = _get_json()
+    username = (data.get("username") or "").strip()
+    password = data.get("password")
+
+    if not username or not password:
+        return jsonify({"error": "username and password are required"}), 400
+
+    if storage.get_user_by_username(username):
+        return jsonify({"error": "username already exists"}), 409
+
+    kyber_pub, kyber_priv = kyber_utils.generate_keypair()
+    dilithium_pub, dilithium_priv = dilithium_utils.generate_keypair()
+
+    created_at = datetime.utcnow().isoformat()
+    user = storage.create_user(
+        username=username,
+        password_hash=generate_password_hash(password),
+        kyber_public_key=kyber_pub,
+        kyber_private_key_enc=keywrap.encrypt_secret(password, kyber_priv),
+        dilithium_public_key=dilithium_pub,
+        dilithium_private_key_enc=keywrap.encrypt_secret(password, dilithium_priv),
+        created_at=created_at,
+    )
+    token = secrets.token_urlsafe(48)
+    now_iso = datetime.utcnow().isoformat()
+    expires_iso = (datetime.utcnow() + timedelta(hours=SESSION_DURATION_HOURS)).isoformat()
+    storage.create_session(user["id"], token, now_iso, expires_iso)
+
+    _cache_session(token, user, kyber_priv, dilithium_priv)
+    return jsonify(_session_payload(user, token, kyber_priv, dilithium_priv)), 201
+
+
+@auth_routes.route("/api/auth/login", methods=["POST"])
+def login() -> Any:
+    data = _get_json()
+    username = (data.get("username") or "").strip()
+    password = data.get("password")
+
+    if not username or not password:
+        return jsonify({"error": "username and password are required"}), 400
+
+    user = storage.get_user_by_username(username)
+    if not user or not check_password_hash(user["password_hash"], password):
+        return jsonify({"error": "invalid credentials"}), 401
+
+    kyber_priv = keywrap.decrypt_secret(password, user["kyber_private_key_enc"])
+    dilithium_priv = keywrap.decrypt_secret(password, user["dilithium_private_key_enc"])
+
+    token = secrets.token_urlsafe(48)
+    now_iso = datetime.utcnow().isoformat()
+    expires_iso = (datetime.utcnow() + timedelta(hours=SESSION_DURATION_HOURS)).isoformat()
+    storage.create_session(user["id"], token, now_iso, expires_iso)
+
+    _cache_session(token, user, kyber_priv, dilithium_priv)
+    return jsonify(_session_payload(user, token, kyber_priv, dilithium_priv))
+
+
+@auth_routes.route("/api/auth/logout", methods=["POST"])
+def logout() -> Any:
+    token = _extract_token()
+    if not token:
+        return jsonify({"error": "missing bearer token"}), 400
+
+    storage.delete_session(token)
+    current_app.config["SESSION_CACHE"].remove(token)
+    return ("", 204)

--- a/backend/routes/message_routes.py
+++ b/backend/routes/message_routes.py
@@ -1,16 +1,187 @@
-from flask import Blueprint, request, jsonify
-from crypto.kyber_utils import encrypt, decrypt
-from crypto.dilithium_utils import sign, verify
+"""Routes for creating and retrieving post-quantum encrypted messages."""
 
-message_routes = Blueprint('messages', __name__)
+from __future__ import annotations
 
-@message_routes.route('/api/messages', methods=['POST'])
-def send_message():
-    data = request.json
-    ciphertext = encrypt(data['recipient_pub'], data['message'])
-    signature = sign(data['sender_priv'], ciphertext)
-    return jsonify({"ciphertext": ciphertext, "signature": signature})
+import hashlib
+from typing import Any, Dict, Optional, Tuple
 
-@message_routes.route('/api/messages', methods=['GET'])
-def get_messages():
-    return jsonify({"messages": []})
+from flask import Blueprint, current_app, jsonify, request
+
+from ..crypto import dilithium_utils, kyber_utils, protocol, symmetric
+from .. import storage
+from ..services.message_service import decrypt_delivery_for_session, serialize_delivery, verify_signature
+from ..websocket.socket_server import socketio
+
+
+message_routes = Blueprint("messages", __name__)
+
+
+def _get_json() -> Dict[str, Any]:
+    return request.get_json(force=True, silent=True) or {}
+
+
+def _extract_token() -> Optional[str]:
+    header = request.headers.get("Authorization", "")
+    if header.startswith("Bearer "):
+        return header[7:]
+    payload = _get_json()
+    token = payload.get("token") if isinstance(payload, dict) else None
+    return token
+
+
+def _require_session() -> Tuple[Optional[str], Optional[Dict[str, str]], Optional[Any]]:
+    token = _extract_token()
+    if not token:
+        return None, None, jsonify({"error": "missing bearer token"}), 401
+    cache = current_app.config["SESSION_CACHE"]
+    session_info = cache.get(token)
+    if not session_info:
+        return None, None, jsonify({"error": "invalid or expired session"}), 401
+    return token, session_info, None, None
+
+
+@message_routes.route("/api/messages", methods=["POST"])
+def send_message() -> Any:
+    token, session_info, error_response, status = _require_session()
+    if error_response is not None:
+        return error_response, status
+
+    data = _get_json()
+    plaintext = (data.get("message") or "").strip()
+    if not plaintext:
+        return jsonify({"error": "message body is required"}), 400
+
+    plaintext_bytes = plaintext.encode("utf-8")
+    now = current_app.config["NOW_FN"]()
+    timestamp_iso = protocol.canonical_timestamp(now)
+    payload_to_sign = protocol.build_signature_payload(
+        session_info["username"], plaintext_bytes, timestamp_iso
+    )
+    signature = dilithium_utils.sign(session_info["dilithium_private_key"], payload_to_sign)
+
+    sender = storage.get_user_by_id(session_info["user_id"])
+    if not sender:
+        return jsonify({"error": "sender not found"}), 400
+
+    digest = hashlib.sha256(plaintext_bytes).hexdigest()
+    message_id = storage.create_message(
+        sender_id=sender["id"],
+        signature=signature,
+        plaintext_digest=digest,
+        created_at=now.isoformat(),
+    )
+
+    message_record = {
+        "id": message_id,
+        "sender_id": sender["id"],
+        "signature": signature,
+        "plaintext_digest": digest,
+        "created_at": now.isoformat(),
+    }
+
+    signature_valid = dilithium_utils.verify(
+        sender["dilithium_public_key"], payload_to_sign, signature
+    )
+    if not signature_valid:  # pragma: no cover - defensive guard
+        raise ValueError("self-signature verification failed")
+
+    payloads = []
+    for recipient in storage.list_users():
+        kem_ciphertext, shared_secret = kyber_utils.encapsulate(recipient["kyber_public_key"])
+        cipher_bundle = symmetric.encrypt(shared_secret, plaintext_bytes)
+        storage.create_delivery(
+            message_id=message_id,
+            recipient_id=recipient["id"],
+            kem_ciphertext=kem_ciphertext,
+            nonce=cipher_bundle.nonce,
+            tag=cipher_bundle.tag,
+            ciphertext=cipher_bundle.ciphertext,
+            created_at=now.isoformat(),
+        )
+        delivery_record = {
+            "message_id": message_id,
+            "recipient_id": recipient["id"],
+            "kem_ciphertext": kem_ciphertext,
+            "nonce": cipher_bundle.nonce,
+            "tag": cipher_bundle.tag,
+            "ciphertext": cipher_bundle.ciphertext,
+            "created_at": now.isoformat(),
+        }
+        payload = serialize_delivery(
+            message=message_record,
+            delivery=delivery_record,
+            sender=sender,
+            plaintext=plaintext_bytes,
+            signature_valid=signature_valid,
+        )
+        payloads.append((recipient["id"], payload))
+
+    registry = current_app.config["SOCKET_REGISTRY"]
+    for recipient_id, payload in payloads:
+        for sid in registry.sids_for_user(recipient_id):
+            socketio.emit("receive_message", payload, room=sid)
+
+    sender_payload = next((p for rid, p in payloads if rid == sender["id"]), payloads[0][1])
+    return jsonify({"message": sender_payload})
+
+
+@message_routes.route("/api/messages", methods=["GET"])
+def get_messages() -> Any:
+    token, session_info, error_response, status = _require_session()
+    if error_response is not None:
+        return error_response, status
+
+    deliveries = storage.deliveries_for_user(session_info["user_id"])
+
+    messages: list[Dict[str, Any]] = []
+    for record in deliveries:
+        delivery = {
+            "message_id": record["message_id"],
+            "kem_ciphertext": record["kem_ciphertext"],
+            "nonce": record["nonce"],
+            "tag": record["tag"],
+            "ciphertext": record["ciphertext"],
+            "created_at": record["created_at"],
+        }
+        message = {
+            "id": record["message_id"],
+            "signature": record["signature"],
+            "plaintext_digest": record["plaintext_digest"],
+            "created_at": record["message_created_at"],
+        }
+        sender = {
+            "id": record["sender_id"],
+            "username": record["sender_username"],
+            "dilithium_public_key": record["dilithium_public_key"],
+        }
+        plaintext = decrypt_delivery_for_session(delivery, session_info)
+        signature_valid = verify_signature(message, plaintext, sender)
+        messages.append(
+            serialize_delivery(
+                message=message,
+                delivery=delivery,
+                sender=sender,
+                plaintext=plaintext,
+                signature_valid=signature_valid,
+            )
+        )
+
+    return jsonify({"messages": messages})
+
+
+@message_routes.route("/api/messages/decrypt", methods=["POST"])
+def decrypt_message() -> Any:
+    token, session_info, error_response, status = _require_session()
+    if error_response is not None:
+        return error_response, status
+
+    data = _get_json()
+    required_fields = {"kem_ciphertext", "nonce", "tag", "ciphertext"}
+    if not required_fields.issubset(data.keys()):
+        return jsonify({"error": "kem_ciphertext, nonce, tag, and ciphertext are required"}), 400
+
+    shared_secret = kyber_utils.decapsulate(session_info["kyber_private_key"], data["kem_ciphertext"])
+    plaintext = symmetric.decrypt(
+        shared_secret, data["nonce"], data["tag"], data["ciphertext"]
+    )
+    return jsonify({"plaintext": plaintext.decode("utf-8")})

--- a/backend/services/message_service.py
+++ b/backend/services/message_service.py
@@ -1,0 +1,59 @@
+"""Message serialization helpers shared between REST and websocket flows."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from ..crypto import dilithium_utils, kyber_utils, protocol, symmetric
+
+
+def decrypt_delivery_for_session(delivery: Dict[str, Any], session_info: Dict[str, str]) -> bytes:
+    """Decrypt an encrypted message delivery for a logged-in session."""
+
+    shared_secret = kyber_utils.decapsulate(session_info["kyber_private_key"], delivery["kem_ciphertext"])
+    plaintext = symmetric.decrypt(
+        shared_secret,
+        delivery["nonce"],
+        delivery["tag"],
+        delivery["ciphertext"],
+    )
+    return plaintext
+
+
+def verify_signature(message: Dict[str, Any], plaintext: bytes, sender: Dict[str, Any]) -> bool:
+    """Verify the Dilithium signature for the provided plaintext."""
+
+    created_at = message.get("created_at") or message.get("message_created_at")
+    if isinstance(created_at, str):
+        created_at = datetime.fromisoformat(created_at)
+    timestamp_iso = protocol.canonical_timestamp(created_at)
+    payload = protocol.build_signature_payload(sender["username"], plaintext, timestamp_iso)
+    return dilithium_utils.verify(sender["dilithium_public_key"], payload, message["signature"])
+
+
+def serialize_delivery(
+    message: Dict[str, Any],
+    delivery: Dict[str, Any],
+    sender: Dict[str, Any],
+    plaintext: bytes,
+    signature_valid: bool,
+) -> Dict[str, object]:
+    """Return a JSON-serialisable payload for clients."""
+
+    created_at = message.get("created_at") or message.get("message_created_at")
+    if isinstance(created_at, str):
+        created_at = datetime.fromisoformat(created_at)
+    timestamp_iso = protocol.canonical_timestamp(created_at)
+    return {
+        "id": message["id"] if "id" in message else message.get("message_id"),
+        "sender": sender["username"],
+        "plaintext": plaintext.decode("utf-8"),
+        "ciphertext": delivery["ciphertext"],
+        "nonce": delivery["nonce"],
+        "tag": delivery["tag"],
+        "kem_ciphertext": delivery["kem_ciphertext"],
+        "signature": message["signature"],
+        "signature_valid": signature_valid,
+        "timestamp": timestamp_iso,
+    }

--- a/backend/session_cache.py
+++ b/backend/session_cache.py
@@ -1,0 +1,39 @@
+"""In-memory cache storing decrypted key material for active sessions."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from threading import RLock
+from typing import Dict, Iterable, Optional
+
+
+class SessionCache:
+    """Thread-safe mapping of tokens to decrypted key material."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._token_to_session: Dict[str, Dict[str, str]] = {}
+        self._user_to_tokens: Dict[int, set[str]] = defaultdict(set)
+
+    def store(self, token: str, session_info: Dict[str, str]) -> None:
+        with self._lock:
+            self._token_to_session[token] = session_info
+            self._user_to_tokens[session_info["user_id"]].add(token)
+
+    def get(self, token: str) -> Optional[Dict[str, str]]:
+        with self._lock:
+            return self._token_to_session.get(token)
+
+    def remove(self, token: str) -> None:
+        with self._lock:
+            session_info = self._token_to_session.pop(token, None)
+            if session_info:
+                tokens = self._user_to_tokens.get(session_info["user_id"])
+                if tokens and token in tokens:
+                    tokens.remove(token)
+                if tokens and not tokens:
+                    self._user_to_tokens.pop(session_info["user_id"], None)
+
+    def tokens_for_user(self, user_id: int) -> Iterable[str]:
+        with self._lock:
+            return list(self._user_to_tokens.get(user_id, set()))

--- a/backend/socket_registry.py
+++ b/backend/socket_registry.py
@@ -1,0 +1,60 @@
+"""Track active Socket.IO connections by authentication token."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from threading import RLock
+from typing import Dict, Iterable
+
+
+class SocketRegistry:
+    """Thread-safe registry mapping tokens to Socket.IO session IDs."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._token_to_sid: Dict[str, str] = {}
+        self._sid_to_token: Dict[str, str] = {}
+        self._user_to_tokens: Dict[int, set[str]] = defaultdict(set)
+
+    def register(self, token: str, user_id: int, sid: str) -> None:
+        with self._lock:
+            self._token_to_sid[token] = sid
+            self._sid_to_token[sid] = token
+            self._user_to_tokens[user_id].add(token)
+
+    def unregister(self, token: str) -> None:
+        with self._lock:
+            sid = self._token_to_sid.pop(token, None)
+            if not sid:
+                return
+            self._sid_to_token.pop(sid, None)
+            for user_id, tokens in list(self._user_to_tokens.items()):
+                if token in tokens:
+                    tokens.remove(token)
+                if not tokens:
+                    self._user_to_tokens.pop(user_id, None)
+
+    def sid_for_token(self, token: str) -> str | None:
+        with self._lock:
+            return self._token_to_sid.get(token)
+
+    def token_for_sid(self, sid: str) -> str | None:
+        with self._lock:
+            return self._sid_to_token.get(sid)
+
+    def sids_for_user(self, user_id: int) -> Iterable[str]:
+        with self._lock:
+            tokens = self._user_to_tokens.get(user_id, set())
+            return [self._token_to_sid[token] for token in tokens if token in self._token_to_sid]
+
+    def unregister_sid(self, sid: str) -> None:
+        with self._lock:
+            token = self._sid_to_token.pop(sid, None)
+            if not token:
+                return
+            self._token_to_sid.pop(token, None)
+            for user_id, tokens in list(self._user_to_tokens.items()):
+                if token in tokens:
+                    tokens.remove(token)
+                if not tokens:
+                    self._user_to_tokens.pop(user_id, None)

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -1,0 +1,199 @@
+"""SQLite helpers backing the Cryptiq persistence layer."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+def _resolve_db_path() -> Path:
+    url = os.environ.get("DATABASE_URL")
+    if url and url.startswith("sqlite:///"):
+        return Path(url.replace("sqlite:///", ""))
+    custom = os.environ.get("DATABASE_PATH")
+    if custom:
+        return Path(custom)
+    return Path(__file__).resolve().parent / "instance" / "cryptiq.db"
+
+
+DB_PATH = _resolve_db_path()
+
+
+SCHEMA: Iterable[str] = (
+    """
+    CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT UNIQUE NOT NULL,
+        password_hash TEXT NOT NULL,
+        kyber_public_key TEXT NOT NULL,
+        kyber_private_key_enc TEXT NOT NULL,
+        dilithium_public_key TEXT NOT NULL,
+        dilithium_private_key_enc TEXT NOT NULL,
+        created_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS sessions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        token TEXT UNIQUE NOT NULL,
+        created_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sender_id INTEGER NOT NULL,
+        signature TEXT NOT NULL,
+        plaintext_digest TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY(sender_id) REFERENCES users(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS message_deliveries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id INTEGER NOT NULL,
+        recipient_id INTEGER NOT NULL,
+        kem_ciphertext TEXT NOT NULL,
+        nonce TEXT NOT NULL,
+        tag TEXT NOT NULL,
+        ciphertext TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE(message_id, recipient_id),
+        FOREIGN KEY(message_id) REFERENCES messages(id) ON DELETE CASCADE,
+        FOREIGN KEY(recipient_id) REFERENCES users(id) ON DELETE CASCADE
+    )
+    """,
+)
+
+
+def init_db() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        for statement in SCHEMA:
+            conn.execute(statement)
+        conn.commit()
+
+
+@contextmanager
+def get_connection() -> Iterable[sqlite3.Connection]:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def create_user(**fields: str) -> Dict[str, object]:
+    now = fields.get("created_at", datetime.utcnow().isoformat())
+    with get_connection() as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO users (username, password_hash, kyber_public_key, kyber_private_key_enc,
+                               dilithium_public_key, dilithium_private_key_enc, created_at)
+            VALUES (:username, :password_hash, :kyber_public_key, :kyber_private_key_enc,
+                    :dilithium_public_key, :dilithium_private_key_enc, :created_at)
+            """,
+            {**fields, "created_at": now},
+        )
+        conn.commit()
+        user_id = cursor.lastrowid
+    return get_user_by_id(user_id)
+
+
+def get_user_by_username(username: str) -> Optional[Dict[str, object]]:
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM users WHERE username = ?", (username,)).fetchone()
+    return dict(row) if row else None
+
+
+def get_user_by_id(user_id: int) -> Optional[Dict[str, object]]:
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM users WHERE id = ?", (user_id,)).fetchone()
+    return dict(row) if row else None
+
+
+def list_users() -> List[Dict[str, object]]:
+    with get_connection() as conn:
+        rows = conn.execute("SELECT * FROM users ORDER BY id ASC").fetchall()
+    return [dict(row) for row in rows]
+
+
+def create_session(user_id: int, token: str, created_at: str, expires_at: str) -> None:
+    with get_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (user_id, token, created_at, expires_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (user_id, token, created_at, expires_at),
+        )
+        conn.commit()
+
+
+def delete_session(token: str) -> None:
+    with get_connection() as conn:
+        conn.execute("DELETE FROM sessions WHERE token = ?", (token,))
+        conn.commit()
+
+
+def get_session(token: str) -> Optional[Dict[str, object]]:
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM sessions WHERE token = ?", (token,)).fetchone()
+    return dict(row) if row else None
+
+
+def create_message(sender_id: int, signature: str, plaintext_digest: str, created_at: str) -> int:
+    with get_connection() as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO messages (sender_id, signature, plaintext_digest, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (sender_id, signature, plaintext_digest, created_at),
+        )
+        conn.commit()
+        return cursor.lastrowid
+
+
+def create_delivery(
+    message_id: int,
+    recipient_id: int,
+    kem_ciphertext: str,
+    nonce: str,
+    tag: str,
+    ciphertext: str,
+    created_at: str,
+) -> None:
+    with get_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO message_deliveries (message_id, recipient_id, kem_ciphertext, nonce, tag, ciphertext, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (message_id, recipient_id, kem_ciphertext, nonce, tag, ciphertext, created_at),
+        )
+        conn.commit()
+
+
+def deliveries_for_user(user_id: int) -> List[Dict[str, object]]:
+    query = """
+        SELECT d.*, m.signature, m.plaintext_digest, m.created_at AS message_created_at,
+               m.sender_id, u.username AS sender_username, u.dilithium_public_key
+        FROM message_deliveries d
+        JOIN messages m ON m.id = d.message_id
+        JOIN users u ON u.id = m.sender_id
+        WHERE d.recipient_id = ?
+        ORDER BY m.created_at ASC
+    """
+    with get_connection() as conn:
+        rows = conn.execute(query, (user_id,)).fetchall()
+    return [dict(row) for row in rows]

--- a/backend/tests/test_crypto.py
+++ b/backend/tests/test_crypto.py
@@ -1,0 +1,94 @@
+import os
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BASE_DIR))
+
+os.environ["DATABASE_URL"] = f"sqlite:///{Path(__file__).parent / 'test.db'}"
+
+import json
+
+import pytest
+
+from backend.app import create_app
+from backend.crypto import dilithium_utils, kyber_utils, symmetric
+
+
+@pytest.fixture(scope="module")
+def app():
+    test_app = create_app()
+    yield test_app
+    db_path = Path(os.environ["DATABASE_URL"].replace("sqlite:///", ""))
+    if db_path.exists():
+        db_path.unlink()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_kyber_roundtrip():
+    public_key, secret_key = kyber_utils.generate_keypair()
+    ciphertext, shared_secret_enc = kyber_utils.encapsulate(public_key)
+    shared_secret_dec = kyber_utils.decapsulate(secret_key, ciphertext)
+    assert shared_secret_enc == shared_secret_dec
+
+
+def test_dilithium_sign_verify():
+    public_key, secret_key = dilithium_utils.generate_keypair()
+    message = b"quantum-secure"
+    signature = dilithium_utils.sign(secret_key, message)
+    assert dilithium_utils.verify(public_key, message, signature)
+    assert not dilithium_utils.verify(public_key, b"tampered", signature)
+
+
+def test_symmetric_encrypt_decrypt():
+    pub, priv = kyber_utils.generate_keypair()
+    ciphertext, shared_enc = kyber_utils.encapsulate(pub)
+    shared_dec = kyber_utils.decapsulate(priv, ciphertext)
+    bundle = symmetric.encrypt(shared_enc, b"hello")
+    plaintext = symmetric.decrypt(shared_dec, bundle.nonce, bundle.tag, bundle.ciphertext)
+    assert plaintext == b"hello"
+
+
+def test_message_flow(client):
+    alice = client.post(
+        "/api/auth/register",
+        json={"username": "alice", "password": "wonderland"},
+    ).get_json()
+    bob = client.post(
+        "/api/auth/register",
+        json={"username": "bob", "password": "builder"},
+    ).get_json()
+
+    send_response = client.post(
+        "/api/messages",
+        headers={"Authorization": f"Bearer {alice['token']}"},
+        json={"message": "Hello Bob"},
+    )
+    assert send_response.status_code == 200
+    payload = send_response.get_json()["message"]
+    assert payload["signature_valid"] is True
+    assert payload["plaintext"] == "Hello Bob"
+
+    history = client.get(
+        "/api/messages",
+        headers={"Authorization": f"Bearer {bob['token']}"},
+    ).get_json()
+    assert any(msg["plaintext"] == "Hello Bob" for msg in history["messages"])
+
+    bob_view = next(msg for msg in history["messages"] if msg["plaintext"] == "Hello Bob")
+    decrypt_body = {
+        key: bob_view[key]
+        for key in ("kem_ciphertext", "nonce", "tag", "ciphertext")
+    }
+    decrypt_response = client.post(
+        "/api/messages/decrypt",
+        headers={"Authorization": f"Bearer {bob['token']}"},
+        data=json.dumps(decrypt_body),
+        content_type="application/json",
+    )
+    assert decrypt_response.status_code == 200
+    assert decrypt_response.get_json()["plaintext"] == "Hello Bob"

--- a/backend/websocket/socket_server.py
+++ b/backend/websocket/socket_server.py
@@ -1,8 +1,66 @@
+"""Socket.IO server that streams encrypted messages to authenticated clients."""
+
+from __future__ import annotations
+
+from flask import current_app, request
 from flask_socketio import SocketIO, emit
 
-socketio = SocketIO(cors_allowed_origins='*')
+from .. import storage
+from ..services.message_service import decrypt_delivery_for_session, serialize_delivery, verify_signature
 
-@socketio.on('send_message')
-def handle_send(data):
-    # data should be {'username': 'nessa', 'message': 'hello'}
-    emit('receive_message', data, broadcast=True)
+
+socketio = SocketIO(cors_allowed_origins="*")
+
+
+@socketio.on("join")
+def handle_join(data):  # type: ignore[override]
+    token = (data or {}).get("token")
+    if not token:
+        emit("error", {"error": "authentication token required"})
+        return
+
+    session_cache = current_app.config["SESSION_CACHE"]
+    session_info = session_cache.get(token)
+    if not session_info:
+        emit("error", {"error": "invalid session"})
+        return
+
+    registry = current_app.config["SOCKET_REGISTRY"]
+    registry.register(token, session_info["user_id"], request.sid)
+
+    emit("status", {"message": "connected", "username": session_info["username"]})
+
+    deliveries = storage.deliveries_for_user(session_info["user_id"])
+
+    for record in deliveries:
+        delivery = {
+            "message_id": record["message_id"],
+            "kem_ciphertext": record["kem_ciphertext"],
+            "nonce": record["nonce"],
+            "tag": record["tag"],
+            "ciphertext": record["ciphertext"],
+            "created_at": record["created_at"],
+        }
+        message = {
+            "id": record["message_id"],
+            "signature": record["signature"],
+            "plaintext_digest": record["plaintext_digest"],
+            "created_at": record["message_created_at"],
+        }
+        sender = {
+            "id": record["sender_id"],
+            "username": record["sender_username"],
+            "dilithium_public_key": record["dilithium_public_key"],
+        }
+        plaintext = decrypt_delivery_for_session(delivery, session_info)
+        signature_valid = verify_signature(message, plaintext, sender)
+        emit(
+            "receive_message",
+            serialize_delivery(message, delivery, sender, plaintext, signature_valid),
+        )
+
+
+@socketio.on("disconnect")
+def handle_disconnect():  # type: ignore[override]
+    registry = current_app.config["SOCKET_REGISTRY"]
+    registry.unregister_sid(request.sid)

--- a/frontend/components/ChatBox.js
+++ b/frontend/components/ChatBox.js
@@ -1,67 +1,223 @@
-import { useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import io from "socket.io-client";
-import UsernameModal from "./UsernameModal"; // Create this as shown earlier
-let socket;
+import UsernameModal from "./UsernameModal";
+
+const backendBaseUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5002";
+const introMessage = {
+  id: "system-intro",
+  system: true,
+  plaintext:
+    "Welcome to Cryptiq. Messages are encapsulated with Kyber-768, signed with Dilithium-3, and verified in real time.",
+};
 
 export default function ChatBox() {
-  const [messages, setMessages] = useState([
-    { message: "Welcome to Cryptiq! All messages are sent with quantum-safe encryption (Kyber/Dilithium). Open this chat in two tabs to test real-time messaging.", system: true }
-  ]);
+  const [auth, setAuth] = useState(null);
+  const [messages, setMessages] = useState([introMessage]);
   const [input, setInput] = useState("");
-  const [username, setUsername] = useState("");
+  const [status, setStatus] = useState("");
+  const [sending, setSending] = useState(false);
+  const [loadingHistory, setLoadingHistory] = useState(false);
   const bottomRef = useRef(null);
+  const messageIds = useRef(new Set());
 
-  useEffect(() => {
-    if (!username) return;
-    socket = io(process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5002");
-    socket.emit('join');
-    socket.on("receive_message", (msg) => {
-      setMessages((prev) => [...prev, msg]);
+  const appendMessage = useCallback(message => {
+    setMessages(prev => {
+      if (message.system) {
+        return [...prev, message];
+      }
+      const exists = messageIds.current.has(message.id);
+      if (exists) {
+        return prev.map(item => (item.id === message.id ? { ...item, ...message } : item));
+      }
+      messageIds.current.add(message.id);
+      return [...prev, message];
     });
-    return () => socket && socket.disconnect();
-  }, [username]);
-  
+  }, []);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const stored = typeof window !== "undefined" ? window.localStorage.getItem("cryptiq-session") : null;
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (parsed?.token && parsed?.user) {
+          setAuth(parsed);
+        }
+      } catch (err) {
+        console.warn("Failed to restore session", err);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (auth) {
+      window.localStorage.setItem("cryptiq-session", JSON.stringify(auth));
+    } else {
+      window.localStorage.removeItem("cryptiq-session");
+    }
+  }, [auth]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  function sendMessage() {
-    if (input.trim() && username) {
-      socket.emit("send_message", { username, message: input });
+  useEffect(() => {
+    if (!auth) return;
+    let cancelled = false;
+    async function fetchHistory() {
+      setLoadingHistory(true);
+      try {
+        const response = await fetch(`${backendBaseUrl}/api/messages`, {
+          headers: { Authorization: `Bearer ${auth.token}` },
+        });
+        const payload = await response.json();
+        if (!response.ok) {
+          throw new Error(payload.error || "Unable to load history");
+        }
+        if (cancelled) return;
+        const history = (payload.messages || []).map(item => ({ ...item, system: false }));
+        messageIds.current = new Set(history.map(item => item.id));
+        setMessages([introMessage, ...history]);
+      } catch (err) {
+        if (!cancelled) setStatus(err.message);
+      } finally {
+        if (!cancelled) setLoadingHistory(false);
+      }
+    }
+    fetchHistory();
+    return () => {
+      cancelled = true;
+    };
+  }, [auth]);
+
+  useEffect(() => {
+    if (!auth) return;
+    const socket = io(backendBaseUrl);
+    socket.emit("join", { token: auth.token });
+    socket.on("status", payload => setStatus(payload.message));
+    socket.on("receive_message", payload => appendMessage({ ...payload, system: false }));
+    socket.on("error", err => setStatus(err.error || "Socket error"));
+    return () => {
+      socket.disconnect();
+    };
+  }, [auth, appendMessage]);
+
+  async function sendMessage() {
+    if (!input.trim() || !auth) return;
+    setSending(true);
+    try {
+      const response = await fetch(`${backendBaseUrl}/api/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${auth.token}`,
+        },
+        body: JSON.stringify({ message: input }),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload.error || "Failed to dispatch message");
+      }
+      if (payload?.message) {
+        appendMessage({ ...payload.message, system: false });
+      }
       setInput("");
+    } catch (err) {
+      setStatus(err.message);
+    } finally {
+      setSending(false);
     }
   }
 
-  if (!username) return <UsernameModal setUsername={setUsername} />;
+  async function handleLogout() {
+    if (!auth) return;
+    try {
+      await fetch(`${backendBaseUrl}/api/auth/logout`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${auth.token}` },
+      });
+    } catch (err) {
+      console.warn("Logout warning", err);
+    } finally {
+      messageIds.current = new Set();
+      setMessages([introMessage]);
+      setAuth(null);
+      setStatus("Disconnected");
+    }
+  }
+
+  if (!auth) {
+    return (
+      <UsernameModal
+        onAuthenticated={session => {
+          setAuth(session);
+          setStatus(`Authenticated as ${session.user.username}`);
+        }}
+      />
+    );
+  }
 
   return (
     <div className="w-full max-w-2xl bg-glass rounded-2xl shadow-[0_0_12px_2px_#08f7fe80] p-6 backdrop-blur-2xl border border-white/20 flex flex-col h-[70vh] relative">
-      {/* Security badge, lighter glow */}
-      {/* <div className="absolute top-2 right-4 text-xs text-neon bg-white/5 px-3 py-1 rounded-full shadow-[0_0_8px_2px_#08f7fe60]">
-        <span role="img" aria-label="lock">🔒</span> Quantum Safe: Kyber/Dilithium
-      </div> */}
-      <h2 className="font-orbitron text-2xl text-neon mb-3">Quantum Chat</h2>
-      <div className="flex-1 overflow-y-auto space-y-2 mb-4 bg-transparent">
-        {messages.map((msg, i) =>
-          msg.system ? (
-            <div
-              key={i}
-              className="text-whiteGlow text-center italic bg-transparent"
-            >
-              {msg.message}
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-orbitron text-2xl text-neon">Quantum Chat</h2>
+        <div className="flex items-center gap-3 text-whiteGlow text-sm">
+          <span className="px-3 py-1 bg-white/10 rounded-full border border-white/10">
+            {auth.user.username}
+          </span>
+          <button
+            onClick={handleLogout}
+            className="text-xs text-neon underline hover:text-whiteGlow"
+          >
+            Logout
+          </button>
+        </div>
+      </div>
+      {status && (
+        <div className="mb-2 text-xs text-amber-200 bg-white/10 px-3 py-2 rounded-lg border border-white/10">
+          {status}
+        </div>
+      )}
+      {loadingHistory && (
+        <div className="mb-2 text-xs text-whiteGlow/70">Synchronizing encrypted history…</div>
+      )}
+      <div className="flex-1 overflow-y-auto space-y-3 mb-4 bg-transparent pr-1">
+        {messages.map(message =>
+          message.system ? (
+            <div key={message.id} className="text-whiteGlow text-center italic bg-transparent">
+              {message.plaintext}
             </div>
           ) : (
             <div
-              key={i}
-              className={
-                msg.username === username
-                  ? "text-whiteGlow bg-white/10 rounded-lg px-3 py-2 max-w-[80%] mx-auto border-l-4 border-neon"
-                  : "text-whiteGlow bg-white/10 rounded-lg px-3 py-2 max-w-[80%] mx-auto"
-              }
+              key={message.id}
+              className={`text-whiteGlow bg-white/10 rounded-lg px-3 py-2 max-w-[85%] border ${
+                message.sender === auth.user.username
+                  ? "ml-auto border-neon"
+                  : "border-white/10"
+              }`}
             >
-              <span className="font-bold text-neon">{msg.username}: </span>
-              {msg.message}
+              <div className="flex items-center justify-between gap-3">
+                <span className="font-bold text-neon">{message.sender}</span>
+                <span className="text-xs text-whiteGlow/60">
+                  {new Date(message.timestamp).toLocaleTimeString()}
+                </span>
+              </div>
+              <p className="mt-1 whitespace-pre-wrap break-words">{message.plaintext}</p>
+              <div className="mt-2 text-xs flex items-center justify-between">
+                <span className={message.signature_valid ? "text-emerald-300" : "text-rose-300"}>
+                  {message.signature_valid ? "Dilithium signature verified" : "Signature invalid"}
+                </span>
+                <span className="text-whiteGlow/50">Kyber ciphertext length: {message.ciphertext.length}</span>
+              </div>
+              <details className="mt-2 text-xs text-whiteGlow/70">
+                <summary className="cursor-pointer text-neon">Cryptographic payload</summary>
+                <div className="mt-1 space-y-1">
+                  <div>Kyber ciphertext: <span className="break-all">{message.kem_ciphertext}</span></div>
+                  <div>Nonce: <span className="break-all">{message.nonce}</span></div>
+                  <div>Tag: <span className="break-all">{message.tag}</span></div>
+                  <div>Dilithium signature: <span className="break-all">{message.signature}</span></div>
+                </div>
+              </details>
             </div>
           )
         )}
@@ -72,19 +228,19 @@ export default function ChatBox() {
           className="flex-1 px-4 py-2 rounded-lg bg-white/20 text-whiteGlow border border-white/10 focus:outline-none focus:border-neon transition"
           value={input}
           onChange={e => setInput(e.target.value)}
-          onKeyDown={e => e.key === "Enter" && sendMessage()}
-          placeholder="Type your quantum message…"
+          onKeyDown={e => e.key === "Enter" && !sending && sendMessage()}
+          placeholder="Compose an encrypted thought…"
         />
         <button
-          className="bg-neon text-darkBg font-bold px-4 py-2 rounded-lg shadow-[0_0_8px_2px_#08f7fe60] hover:bg-whiteGlow transition"
+          className="bg-neon text-darkBg font-bold px-4 py-2 rounded-lg shadow-[0_0_8px_2px_#08f7fe60] hover:bg-whiteGlow transition disabled:opacity-60 disabled:cursor-not-allowed"
           onClick={sendMessage}
+          disabled={sending}
         >
-          Send
+          {sending ? "Sending…" : "Send"}
         </button>
       </div>
-      <br></br>
       <footer className="text-center text-whiteGlow mt-4 text-xs">
-        Powered by Kyber & Dilithium | Designed by Nessa Kodo
+        Post-quantum session secured with Kyber-768 & Dilithium-3
       </footer>
     </div>
   );

--- a/frontend/components/UsernameModal.js
+++ b/frontend/components/UsernameModal.js
@@ -1,11 +1,51 @@
 import { useState } from "react";
 
-export default function UsernameModal({ setUsername }) {
-  const [input, setInput] = useState("");
+const backendBaseUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:5002";
 
-  function handleSubmit(e) {
+export default function UsernameModal({ onAuthenticated }) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [mode, setMode] = useState("login");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e) {
     e.preventDefault();
-    if (input.trim()) setUsername(input.trim());
+    if (!username.trim() || !password) {
+      setError("Username and password are required");
+      return;
+    }
+
+    setSubmitting(true);
+    setError("");
+    try {
+      const endpoint = mode === "register" ? "/api/auth/register" : "/api/auth/login";
+      const response = await fetch(`${backendBaseUrl}${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: username.trim(), password }),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload.error || "Authentication failed");
+      }
+      onAuthenticated({
+        token: payload.token,
+        user: payload.user,
+        keys: payload.keys,
+      });
+      setUsername("");
+      setPassword("");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function toggleMode() {
+    setMode(prev => (prev === "login" ? "register" : "login"));
+    setError("");
   }
 
   return (
@@ -15,27 +55,45 @@ export default function UsernameModal({ setUsername }) {
         className="bg-glass p-12 rounded-2xl shadow-[0_0_18px_4px_#08f7fe40] border border-white/20 flex flex-col items-center max-w-md w-full"
       >
         <h2 className="font-orbitron text-3xl text-neon mb-6 tracking-wide drop-shadow-neon">
-          Welcome to Cryptiq
+          {mode === "login" ? "Rejoin Cryptiq" : "Create Cryptiq Identity"}
         </h2>
-        <p className="text-whiteGlow/90 mb-6 text-sm">
-          Choose a unique username to enter the chat.
+        <p className="text-whiteGlow/90 mb-6 text-sm text-center">
+          {mode === "login"
+            ? "Enter your credentials to unlock your post-quantum keys."
+            : "Register to mint Kyber + Dilithium keys protected by your password."}
         </p>
         <input
-          className="px-6 py-3 mb-6 rounded-xl bg-white/15 text-whiteGlow border border-white/10 focus:outline-none focus:border-neon text-center font-medium text-lg transition w-full"
-          placeholder="Type your handle…"
-          value={input}
-          maxLength={20}
-          onChange={e => setInput(e.target.value)}
+          className="px-6 py-3 mb-4 rounded-xl bg-white/15 text-whiteGlow border border-white/10 focus:outline-none focus:border-neon text-center font-medium text-lg transition w-full"
+          placeholder="Quantum handle"
+          value={username}
+          maxLength={32}
+          onChange={e => setUsername(e.target.value)}
           autoFocus
         />
+        <input
+          className="px-6 py-3 mb-2 rounded-xl bg-white/15 text-whiteGlow border border-white/10 focus:outline-none focus:border-neon text-center font-medium text-lg transition w-full"
+          placeholder="Secret passphrase"
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        {error && <p className="text-rose-300 text-sm mb-4">{error}</p>}
         <button
           type="submit"
-          className="w-full bg-neon text-darkBg font-bold px-8 py-3 rounded-xl shadow-[0_0_10px_2px_#08f7fe30] hover:bg-whiteGlow transition text-lg"
+          disabled={submitting}
+          className="w-full bg-neon text-darkBg font-bold px-8 py-3 rounded-xl shadow-[0_0_10px_2px_#08f7fe30] hover:bg-whiteGlow transition text-lg disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          Enter Chat
+          {submitting ? "Securing…" : mode === "login" ? "Unlock" : "Register"}
         </button>
-        <p className="text-whiteGlow/50 mt-4 text-xs">
-          Your username will be visible to others in this session.
+        <button
+          type="button"
+          onClick={toggleMode}
+          className="text-neon underline mt-4 text-sm hover:text-whiteGlow"
+        >
+          {mode === "login" ? "Need an account? Register" : "Already trusted? Sign in"}
+        </button>
+        <p className="text-whiteGlow/50 mt-4 text-xs text-center">
+          Private keys are encrypted with your password and never shared with other users.
         </p>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- replace the placeholder crypto helpers with Kyber-768 and Dilithium-3 integrations, including password-wrapped private keys and deterministic fallbacks when liboqs is unavailable
- add SQLite-backed persistence, session caching, Socket.IO routing, and REST endpoints for registration, login, message send/retrieve/decrypt along with a pytest suite covering the new cryptographic flow
- update the Next.js chat UI with authenticated onboarding, encrypted history synchronisation, signature telemetry, and backend-driven message dispatch

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf98f549cc83209bbf10a0bc56782e